### PR TITLE
feat(core): implement foundational enums

### DIFF
--- a/python/src/ptms/core/enums/__init__.py
+++ b/python/src/ptms/core/enums/__init__.py
@@ -1,0 +1,15 @@
+from .asset import AssetClass
+from .country import CountryCode
+from .currency import CurrencyCode
+from .document import DocumentType
+from .event import EventType
+from .tax import TaxRegime
+
+__all__ = [
+    "AssetClass",
+    "CountryCode",
+    "CurrencyCode",
+    "DocumentType",
+    "EventType",
+    "TaxRegime",
+]

--- a/python/src/ptms/core/enums/asset.py
+++ b/python/src/ptms/core/enums/asset.py
@@ -1,0 +1,11 @@
+from enum import StrEnum
+
+
+class AssetClass(StrEnum):
+    """Supported financial asset classes."""
+
+    RSU = "RSU"
+    EQUITY = "EQUITY"
+    MUTUAL_FUND = "MUTUAL_FUND"
+    PROPERTY = "PROPERTY"
+    CASH = "CASH"

--- a/python/src/ptms/core/enums/country.py
+++ b/python/src/ptms/core/enums/country.py
@@ -1,0 +1,13 @@
+from enum import StrEnum
+
+
+class CountryCode(StrEnum):
+    """ISO 3166-1 alpha-2 country codes supported by PTMS."""
+
+    IN = "IN"
+    US = "US"
+    GB = "GB"
+    AU = "AU"
+    CA = "CA"
+    SG = "SG"
+    NZ = "NZ"

--- a/python/src/ptms/core/enums/country.py
+++ b/python/src/ptms/core/enums/country.py
@@ -1,13 +1,15 @@
 from enum import StrEnum
 
+"""Country code enumerations used throughout PTMS."""
+
 
 class CountryCode(StrEnum):
     """ISO 3166-1 alpha-2 country codes supported by PTMS."""
 
-    IN = "IN"
-    US = "US"
-    GB = "GB"
     AU = "AU"
     CA = "CA"
-    SG = "SG"
+    GB = "GB"
+    IN = "IN"
     NZ = "NZ"
+    SG = "SG"
+    US = "US"

--- a/python/src/ptms/core/enums/currency.py
+++ b/python/src/ptms/core/enums/currency.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+
+class CurrencyCode(StrEnum):
+    """ISO 4217 currency codes."""
+
+    INR = "INR"
+    USD = "USD"
+    GBP = "GBP"
+    EUR = "EUR"
+    AUD = "AUD"
+    CAD = "CAD"
+    SGD = "SGD"
+    NZD = "NZD"

--- a/python/src/ptms/core/enums/currency.py
+++ b/python/src/ptms/core/enums/currency.py
@@ -1,14 +1,16 @@
 from enum import StrEnum
 
+"""Currency code enumerations used throughout PTMS."""
+
 
 class CurrencyCode(StrEnum):
     """ISO 4217 currency codes."""
 
-    INR = "INR"
-    USD = "USD"
-    GBP = "GBP"
-    EUR = "EUR"
     AUD = "AUD"
     CAD = "CAD"
-    SGD = "SGD"
+    EUR = "EUR"
+    GBP = "GBP"
+    INR = "INR"
     NZD = "NZD"
+    SGD = "SGD"
+    USD = "USD"

--- a/python/src/ptms/core/enums/document.py
+++ b/python/src/ptms/core/enums/document.py
@@ -1,0 +1,11 @@
+from enum import StrEnum
+
+
+class DocumentType(StrEnum):
+    """Supported document types."""
+
+    FORM16 = "FORM16"
+    AIS = "AIS"
+    BROKER_STATEMENT = "BROKER_STATEMENT"
+    HOME_LOAN_CERTIFICATE = "HOME_LOAN_CERTIFICATE"
+    BANK_STATEMENT = "BANK_STATEMENT"

--- a/python/src/ptms/core/enums/document.py
+++ b/python/src/ptms/core/enums/document.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
 
+"""Document type enumerations used throughout PTMS."""
+
 
 class DocumentType(StrEnum):
     """Supported document types."""

--- a/python/src/ptms/core/enums/event.py
+++ b/python/src/ptms/core/enums/event.py
@@ -1,0 +1,11 @@
+from enum import StrEnum
+
+
+class EventType(StrEnum):
+    """Financial events tracked by PTMS."""
+
+    GRANT = "GRANT"
+    VEST = "VEST"
+    RELEASE = "RELEASE"
+    SALE = "SALE"
+    DIVIDEND = "DIVIDEND"

--- a/python/src/ptms/core/enums/tax.py
+++ b/python/src/ptms/core/enums/tax.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+
+class TaxRegime(StrEnum):
+    """Indian income tax regimes."""
+
+    OLD = "OLD"
+    NEW = "NEW"

--- a/python/tests/ptms/core/enums/test_enums.py
+++ b/python/tests/ptms/core/enums/test_enums.py
@@ -1,0 +1,58 @@
+from enum import StrEnum
+
+import pytest
+from ptms.core.enums import (
+    AssetClass,
+    CountryCode,
+    CurrencyCode,
+    DocumentType,
+    EventType,
+    TaxRegime,
+)
+
+
+@pytest.mark.parametrize(
+    ("enum_cls", "expected_values"),
+    [
+        (CountryCode, {"IN", "US", "GB", "AU", "CA", "SG", "NZ"}),
+        (CurrencyCode, {"INR", "USD", "GBP", "EUR", "AUD", "CAD", "SGD", "NZD"}),
+        (
+            DocumentType,
+            {
+                "FORM16",
+                "AIS",
+                "BROKER_STATEMENT",
+                "HOME_LOAN_CERTIFICATE",
+                "BANK_STATEMENT",
+            },
+        ),
+        (EventType, {"GRANT", "VEST", "RELEASE", "SALE", "DIVIDEND"}),
+        (TaxRegime, {"OLD", "NEW"}),
+        (AssetClass, {"RSU", "EQUITY", "MUTUAL_FUND", "PROPERTY", "CASH"}),
+    ],
+)
+def test_enum_values(enum_cls: type[StrEnum], expected_values: set[str]) -> None:
+    actual_values = {item.value for item in enum_cls}
+    assert actual_values == expected_values
+
+
+@pytest.mark.parametrize(
+    ("enum_cls", "valid_value", "invalid_value"),
+    [
+        (CountryCode, "IN", "XX"),
+        (CurrencyCode, "INR", "ABC"),
+        (DocumentType, "FORM16", "PAN"),
+        (EventType, "VEST", "BONUS"),
+        (TaxRegime, "OLD", "DEFAULT"),
+        (AssetClass, "RSU", "BOND"),
+    ],
+)
+def test_enum_lookup_and_invalid_value(
+    enum_cls: type[StrEnum], valid_value: str, invalid_value: str
+) -> None:
+    member = enum_cls(valid_value)
+    assert member.value == valid_value
+    assert isinstance(member, str)
+
+    with pytest.raises(ValueError):
+        enum_cls(invalid_value)


### PR DESCRIPTION
## Why

This change establishes a shared, typed enum foundation for core PTMS domain concepts so downstream modules can use consistent constants and avoid string drift.

---

## What

- Added `ptms.core` package and `ptms.core.enums` exports
- Added enums:
  - `CountryCode`
  - `CurrencyCode`
  - `DocumentType`
  - `EventType`
  - `TaxRegime`
  - `AssetClass`
- Added consolidated parameterized tests for all enums

---

## How

Implemented each enum as `StrEnum` to keep values string-compatible while still strongly typed. Added package-level exports via `__init__.py` and a unified test module validating values, lookup behavior, invalid values, and string compatibility.

---

## Tests

How was it tested?

- `uv run ruff check .`
- `uv run mypy python/tests/ptms/core/enums/test_enums.py`
- `uv run pytest -q python/tests/ptms/core/enums`

All checks passed locally.

---

## Documentation

No documentation files changed in this PR. This is a code-and-tests foundational change.

---

## ADR

Does this require an ADR?

No

---

## Review Checklist

- [x] Correctness
- [x] Simplicity
- [x] Readability
- [x] Tests
- [x] Documentation
- [x] Type Safety
- [x] Backward Compatibility
- [x] Performance (only if relevant)
