### PR TITLE
docs(assessment-year): add RFC and ADR baseline

### DIFF
--- a/docs/adr/ADR-001-CleanArchitecture.md
+++ b/docs/adr/ADR-001-CleanArchitecture.md
@@ -42,4 +42,13 @@ Business logic should never change because the UI changed.
 
  Excel   CLI   PDF   REST API   Web UI
 
+## Canonical Representation Principle
+
+Every Value Object follows these rules:
+
+- One canonical internal representation.
+- One canonical string representation (`__str__`).
+- Zero or more parsing formats.
+- Presentation-specific formatting belongs outside the domain unless it represents a distinct business concept.
+
 

--- a/docs/adr/ADR-006-ISO-Standards.md
+++ b/docs/adr/ADR-006-ISO-Standards.md
@@ -6,12 +6,107 @@ Accepted
 
 ## Context
 
-...
+PTMS processes tax and portfolio data across multiple jurisdictions and data sources.
+
+Without standardized identifiers and formats, the platform risks inconsistent parsing, duplicate mappings, and ambiguous reporting outputs.
+
+To keep core domain behavior deterministic, PTMS needs explicit standards for country codes, currency codes, and date representations.
 
 ## Decision
 
-...
+PTMS adopts the following ISO standards as canonical defaults in domain and persistence-facing boundaries.
+
+### 1. Country Codes
+
+- Standard: ISO 3166-1 alpha-2.
+- Representation: two-letter uppercase country code.
+- PTMS domain type: `CountryCode` enum.
+
+Examples:
+
+- `IN`, `US`, `GB`, `SG`.
+
+### 2. Currency Codes
+
+- Standard: ISO 4217 alphabetic currency codes.
+- Representation: three-letter uppercase currency code.
+- PTMS domain type: `CurrencyCode` enum.
+
+Examples:
+
+- `INR`, `USD`, `GBP`, `SGD`.
+
+### 3. Dates and Period Strings
+
+- Standard: ISO 8601 for machine-readable dates and date-like strings.
+- Canonical date format: `YYYY-MM-DD`.
+- Canonical year format (where applicable): `YYYY`.
+
+### 4. Casing and Normalization
+
+- Inputs may be normalized at ingress boundaries.
+- Internal domain values must remain canonical uppercase ISO codes.
+
+## Scope
+
+This ADR governs:
+
+- Domain primitives and enums for country and currency identity.
+- API/request/response contracts that carry these identifiers.
+- Storage and export layers that require stable machine-readable formats.
+
+This ADR does not govern:
+
+- Human-friendly localized display text.
+- Exchange rate sourcing.
+- Country- or currency-specific legal calculations.
+
+## Rationale
+
+- ISO standards reduce ambiguity in integrations.
+- Standards-aligned enums improve type safety and validation.
+- Canonical formats simplify joins, lookups, and long-term maintenance.
 
 ## Consequences
 
-...
+### Positive
+
+- Consistent identifiers across modules and services.
+- Fewer data-quality defects from free-form strings.
+- Cleaner interoperability with external datasets and tools.
+
+### Negative
+
+- Legacy or non-ISO inputs require normalization/adapters.
+- Some edge-case external naming conventions may be rejected until mapped.
+
+## Alternatives Considered
+
+### 1. Free-form strings everywhere
+
+Rejected.
+
+Reason:
+
+- No canonical validation.
+- High risk of drift and typo defects.
+
+### 2. Vendor-specific codes only
+
+Rejected.
+
+Reason:
+
+- Locks PTMS to specific data providers.
+- Reduces portability and transparency.
+
+## Implementation Notes
+
+- `CountryCode` and `CurrencyCode` enums are authoritative in the domain layer.
+- Unknown inbound identifiers must fail fast or be mapped explicitly in adapters.
+- Future extensions should preserve ISO compatibility and avoid introducing parallel code systems.
+
+## Related
+
+- ADR-007 Money Value Object.
+- RFC-001 Assessment Year Domain Model.

--- a/docs/adr/ADR-007-Money.md
+++ b/docs/adr/ADR-007-Money.md
@@ -137,6 +137,16 @@ The following behaviors must be verified through automated tests:
 - [x] Hash semantics
 - [x] Invalid operations
 
+## Validation
+
+This ADR is considered implemented when:
+
+- [x] Unit tests exist
+- [x] Documentation updated
+- [x] MyPy passes
+- [x] Ruff passes
+- [x] Public API documented
+
 ## Scope
 
 This ADR defines the core monetary abstraction used throughout PTMS.

--- a/docs/adr/ADR-008-AssessmentYear.md
+++ b/docs/adr/ADR-008-AssessmentYear.md
@@ -1,0 +1,106 @@
+# ADR-008: AssessmentYear Value Object
+
+## Status
+
+Proposed
+
+## Context
+
+PTMS requires a stable and explicit representation of the Indian Assessment Year across tax computation, validation, and reporting workflows.
+
+Using primitives (`int` or `str`) would scatter validation and formatting logic and make domain rules harder to reason about.
+
+RFC-001 defines `AssessmentYear` as a foundational domain primitive and positions it alongside existing value objects such as `Money`.
+
+## Decision
+
+PTMS will introduce `AssessmentYear` as an immutable value object.
+
+### Immutability
+
+- Instances are immutable after construction.
+- Any transformation (for example `next()` or `previous()`) returns a new instance.
+
+### Internal Representation
+
+- Canonical internal representation is `start_year: int`.
+- `end_year` is derived as `start_year + 1`.
+- Construction validates Indian AY shape (consecutive years).
+
+### Canonical Representation
+
+The canonical string representation of an AssessmentYear is:
+
+`AY 2026-27`
+
+### Equality
+
+- Two `AssessmentYear` values are equal when `start_year` matches.
+- Equality is value-based, not identity-based.
+
+### Comparison
+
+- Ordering reflects chronological ordering of Assessment Years.
+- `AssessmentYear(2026) > AssessmentYear(2025)` is valid and meaningful.
+
+### Hashing
+
+- Hash is derived from immutable value state (`start_year`).
+- Equal objects must produce equal hashes.
+
+## Invariants
+
+AssessmentYear
+
+- `start_year` is immutable
+- `end_year == start_year + 1`
+- equality uses `start_year`
+- ordering uses chronological order
+
+## Consequences
+
+### Positive
+
+- Clear domain semantics for AY.
+- Reusable primitive across modules.
+- Safer APIs with centralized validation.
+
+### Negative
+
+- Requires migration away from primitive integers/strings.
+- Adds one more core object to maintain and document.
+
+## Out of Scope
+
+- Tax slab computation.
+- Deduction rule enforcement.
+- Historical tax-law interpretation.
+
+## Alternatives Considered
+
+Primitive int
+
+- No domain semantics
+- No centralized validation
+
+Primitive str
+
+- Parsing required everywhere
+- Easy to create invalid values
+
+## Validation
+
+This ADR is considered implemented when:
+
+- [ ] Unit tests exist
+- [ ] Documentation updated
+- [ ] MyPy passes
+- [ ] Ruff passes
+- [ ] Public API documented
+
+## Related
+
+- ADR-001 Clean Architecture
+- ADR-009 AssessmentYear Parsing
+- ADR-010 AssessmentYear and FinancialYear Relationship
+- RFC-001 Assessment Year Domain Model.

--- a/docs/adr/ADR-009-AssessmentYear-Parsing.md
+++ b/docs/adr/ADR-009-AssessmentYear-Parsing.md
@@ -1,0 +1,104 @@
+# ADR-009: AssessmentYear Parsing
+
+## Status
+
+Proposed
+
+## Context
+
+Assessment Year values will enter PTMS through user input, imports, and external integrations.
+
+Without a consistent parsing policy, multiple incompatible AY text formats will appear across modules and increase validation defects.
+
+RFC-001 identifies parsing as a key risk and calls for incremental hardening.
+
+## Decision
+
+PTMS parsing for `AssessmentYear` will be strict in v1 while supporting a small set of explicit formats.
+
+### Accepted Inputs
+
+The parser accepts:
+
+- `2026`
+- `AY 2026-27`
+- `2026-2027`
+
+### Strictness Policy
+
+- Parsing is strict, not permissive.
+- Input must match one of the accepted formats exactly after trimming leading/trailing whitespace.
+- Invalid tokens (for example `A.Y. 2026-27`, `26-27`, `AY2026-27`) are rejected.
+- Year continuity is validated (`end_year == start_year + 1`).
+
+### Canonicalization
+
+- Parsed output normalizes to a single canonical object (`AssessmentYear(start_year=2026)`).
+- String rendering from the value object should be canonical and deterministic.
+
+## Alternatives Considered
+
+### 1. Permissive parsing
+
+Rejected.
+
+Reason:
+
+- Encourages ambiguous input handling.
+- Makes validation behavior harder to reason about.
+
+### 2. Single-format parsing only
+
+Rejected.
+
+Reason:
+
+- Too restrictive for realistic ingress paths.
+- Forces avoidable normalization work onto every caller.
+
+## Invariants
+
+- Accepted formats normalize to the same canonical `AssessmentYear` value.
+- Invalid formats are rejected deterministically.
+- Parsing never changes the canonical internal representation.
+
+## Consequences
+
+### Positive
+
+- Predictable and testable parser behavior.
+- Lower ambiguity between FY and AY.
+- Better data quality at entry points.
+
+### Negative
+
+- Some real-world variants are intentionally rejected.
+- Integrations may need pre-normalization before PTMS parse.
+
+## Future Evolution
+
+- Additional human formats may be added only via new ADR or ADR amendment decision.
+- Any expansion must preserve backward compatibility of existing accepted formats.
+
+## Out of Scope
+
+- User-interface-specific formatting beyond canonical domain parsing.
+- Historical tax-law interpretation tied to specific year labels.
+- Fuzzy or heuristic parsing of malformed inputs.
+
+## Validation
+
+This ADR is considered implemented when:
+
+- [ ] Unit tests exist
+- [ ] Documentation updated
+- [ ] MyPy passes
+- [ ] Ruff passes
+- [ ] Public API documented
+
+## Related
+
+- ADR-001 Clean Architecture
+- ADR-008 AssessmentYear Value Object.
+- ADR-010 AssessmentYear and FinancialYear Relationship.
+- RFC-001 Assessment Year Domain Model.

--- a/docs/adr/ADR-010-AssessmentYear-FinancialYear-Relationship.md
+++ b/docs/adr/ADR-010-AssessmentYear-FinancialYear-Relationship.md
@@ -1,0 +1,100 @@
+# ADR-010: AssessmentYear and FinancialYear Relationship
+
+## Status
+
+Proposed
+
+## Context
+
+Indian tax logic uses both Financial Year (FY) and Assessment Year (AY), and they are offset by one year.
+
+Confusion between AY and FY is a known domain risk from RFC-001, so the relationship must be explicit and deterministic.
+
+## Decision
+
+PTMS will model `FinancialYear` as a separate value object and compute AY/FY conversion, not duplicate stored state.
+
+### Storage Strategy
+
+- `AssessmentYear` stores only AY canonical state (`start_year`).
+- `FinancialYear` stores only FY canonical state (`start_year`).
+
+### Conversion Strategy
+
+- `AssessmentYear.financial_year` is computed from AY (`FY.start_year = AY.start_year - 1`).
+- `FinancialYear.assessment_year` is computed from FY (`AY.start_year = FY.start_year + 1`).
+
+### Eager vs Lazy
+
+- Conversion may be implemented as a computed property (lazy by access).
+- No cached duplicate field is stored in either object in v1.
+- Conversion is O(1), so caching provides negligible benefit while introducing consistency risks.
+- Conversion methods never mutate either value object.
+
+## Alternatives Considered
+
+### 1. Store both AY and FY on each object
+
+Rejected.
+
+Reason:
+
+- Duplicates derived state.
+- Introduces consistency and synchronization risk.
+
+### 2. Model only AssessmentYear and use raw integers for FY
+
+Rejected.
+
+Reason:
+
+- Weakens domain clarity.
+- Loses type safety for a distinct business concept.
+
+## Invariants
+
+- AY and FY conversion is deterministic and reversible.
+- Conversion never mutates either value object.
+- No cached duplicate year state is stored in v1.
+
+## Rationale
+
+- Keeps each value object single-purpose and immutable.
+- Prevents drift from duplicated AY/FY state.
+- Maintains explicit ubiquitous language in domain APIs.
+
+## Consequences
+
+### Positive
+
+- Clear separation of concepts.
+- Simple and reliable conversion rules.
+- Safer type-level modeling in services and validation.
+
+### Negative
+
+- Requires an additional value object (`FinancialYear`) in foundation scope.
+- Existing code using raw integers will need migration.
+
+## Out of Scope
+
+- Tax law rate tables.
+- Year-specific legal rule activation.
+- Localization and presentation formatting.
+
+## Validation
+
+This ADR is considered implemented when:
+
+- [ ] Unit tests exist
+- [ ] Documentation updated
+- [ ] MyPy passes
+- [ ] Ruff passes
+- [ ] Public API documented
+
+## Related
+
+- ADR-001 Clean Architecture
+- ADR-008 AssessmentYear Value Object.
+- ADR-009 AssessmentYear Parsing.
+- RFC-001 Assessment Year Domain Model.

--- a/docs/adr/ADR_TEMPLATE.md
+++ b/docs/adr/ADR_TEMPLATE.md
@@ -1,0 +1,59 @@
+# ADR-XXX: Title
+
+## Status
+
+Proposed
+
+## Context
+
+Describe the business and technical context that makes this decision necessary.
+
+## Decision
+
+State the decision clearly and unambiguously.
+
+## Alternatives Considered
+
+### Option A
+
+Describe the alternative.
+
+Rejected / Accepted / Deferred.
+
+### Option B
+
+Describe the alternative.
+
+Rejected / Accepted / Deferred.
+
+## Invariants
+
+List the rules that must always remain true after this decision is implemented.
+
+## Consequences
+
+### Positive
+
+- Describe the positive outcomes.
+
+### Negative
+
+- Describe the tradeoffs or costs.
+
+## Out of Scope
+
+- List concerns intentionally excluded from this ADR.
+
+## Validation
+
+This ADR is considered implemented when:
+
+- [ ] Unit tests exist
+- [ ] Documentation updated
+- [ ] MyPy passes
+- [ ] Ruff passes
+- [ ] Public API documented
+
+## Related
+
+- Link related RFCs and ADRs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,15 @@ Every architectural decision that affects the long-term direction of PTMS should
 ADRs are immutable historical records.
 
 If a decision changes, create a new ADR instead of modifying the old one.
+
+## Index
+
+- ADR-001 Clean Architecture
+- ADR-002 Why SQLite
+- ADR-003 Why UV
+- ADR-004 Workbook As Presentation
+- ADR-006 ISO Standards
+- ADR-007 Money Value Object
+- ADR-008 AssessmentYear Value Object
+- ADR-009 AssessmentYear Parsing
+- ADR-010 AssessmentYear and FinancialYear Relationship

--- a/docs/architecture/DomainRoadmap.md
+++ b/docs/architecture/DomainRoadmap.md
@@ -1,0 +1,13 @@
+# Domain Roadmap
+
+## Foundation
+
+- Money ✔
+- AssessmentYear
+- FinancialYear
+- TaxRate
+- PAN
+- Income
+- Deduction
+- ITR
+- Calculation Engine

--- a/docs/engineering/GitWorkflow.md
+++ b/docs/engineering/GitWorkflow.md
@@ -1,0 +1,79 @@
+# Git Workflow
+
+## Branch Naming
+
+- Use lowercase, hyphenated branch names.
+- Prefix by intent:
+	- `feature/<ticket-or-scope>`
+	- `fix/<ticket-or-scope>`
+	- `refactor/<ticket-or-scope>`
+	- `design/<ticket-or-scope>`
+	- `docs/<ticket-or-scope>`
+- Include the work item when available (example: `feature/PTMS-024-money-scalar-arithmetic`).
+
+## Commit Message Format
+
+- Follow Conventional Commits.
+- Allowed types in this repository: `feat`, `fix`, `docs`, `refactor`.
+- Format:
+
+```text
+<type>(<scope>): <short summary>
+```
+
+- Examples:
+	- `feat(money): support money-to-money ratio division`
+	- `docs(adr): add assessment year parsing decision`
+
+## PR Expectations
+
+- Open PRs against `main` unless explicitly planned otherwise.
+- Use the PR template in `.github/pull_request_template.md`.
+- Fill all sections: Why, What, How, Tests, Documentation, ADR, Review Checklist.
+- Keep PRs focused and scoped to one concern where possible.
+- Include evidence of validation (lint, type-check, tests).
+
+## RFC Process
+
+- Create an RFC in `docs/rfcs/` for new domain capabilities or major behavior changes.
+- RFC status starts as `Draft`.
+- RFC must define:
+	- Summary
+	- Motivation
+	- Goals and Non-Goals
+	- Alternatives
+	- Risks
+	- Success Criteria
+- After review alignment, promote key decisions into ADRs.
+
+## ADR Process
+
+- Create ADRs in `docs/adr/` with incremental numbering.
+- ADRs are historical records; do not rewrite accepted intent retroactively.
+- Each ADR should include:
+	- Status
+	- Context
+	- Decision
+	- Consequences
+	- Scope and Non-Goals (when applicable)
+	- Related RFC/ADR links
+- If a decision changes, write a new ADR that supersedes the prior one.
+
+## Review Checklist
+
+- Correctness
+- Simplicity
+- Readability
+- Tests
+- Documentation
+- Type Safety
+- Backward Compatibility
+- Performance (when relevant)
+
+## Release Process
+
+- Merge approved PRs into `main` through the standard review flow.
+- Ensure CI is green before merge.
+- Use Conventional Commits to support semantic versioning and release notes.
+- Tag releases following SemVer.
+- Publish release notes summarizing user-visible changes and migration notes.

--- a/docs/rfcs/RFC-001-AssessmentYear.md
+++ b/docs/rfcs/RFC-001-AssessmentYear.md
@@ -1,0 +1,180 @@
+# RFC-001 — Assessment Year Domain Model
+
+**Status:** Reviewed
+
+**Authors:** Pranay Joshi
+
+**Reviewers:** PTMS Architecture Review
+
+**Target Release:** Foundation v2.0
+
+---
+
+# 1. Summary
+
+Introduce a first-class `AssessmentYear` value object that models the assessment year used throughout the Indian Income Tax system.
+
+The Assessment Year will become one of the core domain primitives and will be used by every tax computation, tax return, validation rule, and reporting feature within PTMS.
+
+---
+
+# 2. Motivation
+
+Currently PTMS has a production-ready `Money` value object.
+
+However, almost every business rule in Indian taxation is dependent on the applicable Assessment Year.
+
+Examples include:
+
+- Income tax slab rates
+- Standard deduction
+- Section deduction limits
+- Capital gains rules
+- Rebate calculations
+- Surcharge thresholds
+- Validation rules
+- Supported ITR forms
+
+Without a first-class Assessment Year object these rules would eventually become scattered across the codebase.
+
+---
+
+# 3. Goals
+
+The Assessment Year should:
+
+- represent a valid Indian Assessment Year
+- be immutable
+- support comparison
+- support equality and hashing
+- provide a canonical string representation
+- support conversion to Financial Year
+- become a reusable domain primitive
+
+---
+
+# 4. Non-Goals
+
+The first version will **not**:
+
+- calculate tax slabs
+- validate deduction limits
+- understand CBDT notifications
+- support historical law changes
+
+Those responsibilities belong to higher-level domain services.
+
+---
+
+# 5. Why a Value Object?
+
+Assessment Year has no identity.
+
+These represent the same concept:
+
+```python
+AssessmentYear(2026)
+AssessmentYear.of(2026)
+AssessmentYear.parse("AY 2026-27")
+```
+
+Therefore it satisfies the DDD definition of a Value Object.
+
+---
+
+# 6. Ubiquitous Language
+
+| Term | Meaning |
+|------|---------|
+| Assessment Year | Year in which income is assessed |
+| Financial Year | Year in which income is earned |
+| AY | Assessment Year |
+| FY | Financial Year |
+
+---
+
+# 7. Proposed Public API (Illustrative)
+
+```python
+AssessmentYear.of(2026)
+
+AssessmentYear.parse("AY 2026-27")
+
+str(ay)
+
+repr(ay)
+
+ay.start_year
+
+ay.end_year
+
+ay.financial_year
+
+ay.next()
+
+ay.previous()
+```
+
+This is illustrative only; the ADR will finalize the API.
+
+---
+
+# 8. Alternatives Considered
+
+## Option A
+
+Represent Assessment Year as an `int`.
+
+Rejected.
+
+Lacks expressiveness and validation.
+
+---
+
+## Option B
+
+Represent Assessment Year as a `str`.
+
+Rejected.
+
+Allows invalid values and requires repeated parsing.
+
+---
+
+## Option C
+
+Dedicated immutable Value Object.
+
+**Chosen.**
+
+Consistent with our Money implementation and DDD principles.
+
+---
+
+# 9. Risks
+
+- Confusion between FY and AY.
+- Supporting future tax law changes.
+- Parsing multiple human-readable formats.
+
+These will be addressed incrementally.
+
+---
+
+# 10. Success Criteria
+
+The RFC will be considered successful when:
+
+- Assessment Year is implemented as a Value Object.
+- All tests pass.
+- API is documented.
+- ADR is approved.
+- PTMS uses Assessment Year instead of primitive integers.
+
+---
+
+# 11. Related ADRs
+
+- ADR-008 AssessmentYear Value Object
+- ADR-009 AssessmentYear Parsing
+- ADR-010 AssessmentYear and FinancialYear Relationship


### PR DESCRIPTION
## Why

PTMS needs an architectural baseline for the AssessmentYear domain before implementation work begins. This PR documents the domain model, parsing strategy, AssessmentYear-to-FinancialYear relationship, and related domain rules so future implementation stories can build on a reviewed design.

---

## What

## Summary

Introduces RFC-001 for the AssessmentYear domain model and the supporting ADRs that establish:

- AssessmentYear as a Value Object
- Parsing strategy
- AssessmentYear ↔ FinancialYear relationship
- Domain invariants
- Canonical representation principles

No production code is included in this PR.

This PR establishes the architectural baseline for future AssessmentYear implementation stories.

---

## How

- Added RFC-001 for the AssessmentYear domain model.
- Added ADR-008, ADR-009, and ADR-010 for value-object modeling, parsing, and AY/FY relationship decisions.
- Updated shared architecture/process docs including ADR index, ADR template, Git workflow guidance, and ISO/clean-architecture references where needed for consistency.
- Linked related RFCs and ADRs to create a coherent documentation set.

---

## Tests

No production code is included in this PR, so no runtime tests were added or executed.

Documentation was reviewed for consistency, status alignment, cross-references, and removal of placeholder text.

---

## Documentation

Updated documentation includes:

- `docs/rfcs/RFC-001-AssessmentYear.md`
- `docs/adr/ADR-001-CleanArchitecture.md`
- `docs/adr/ADR-006-ISO-Standards.md`
- `docs/adr/ADR-007-Money.md`
- `docs/adr/ADR-008-AssessmentYear.md`
- `docs/adr/ADR-009-AssessmentYear-Parsing.md`
- `docs/adr/ADR-010-AssessmentYear-FinancialYear-Relationship.md`
- `docs/adr/ADR_TEMPLATE.md`
- `docs/adr/README.md`
- `docs/engineering/GitWorkflow.md`

---

## ADR

Yes

---

## Review Checklist

- [x] Correctness
- [x] Simplicity
- [x] Readability
- [x] Tests
- [x] Documentation
- [x] Type Safety
- [x] Backward Compatibility
- [x] Performance (only if relevant)
