### PR TITLE
feat(money): implement canonical string representation

### DIFF
--- a/python/src/ptms/core/value_objects/money.py
+++ b/python/src/ptms/core/value_objects/money.py
@@ -160,6 +160,20 @@ class Money:
         )
 
     # -----------------------------
+    # String Representation
+    # -----------------------------
+
+    def __str__(self) -> str:
+        """
+        Return canonical string representation.
+
+        Format: ``<amount> <currency>``
+        Example: ``100.50 INR``
+        """
+
+        return f"{self.amount} {self.currency.value}"
+
+    # -----------------------------
     # Unary Operations
     # -----------------------------
 

--- a/python/tests/ptms/core/value_objects/test_money.py
+++ b/python/tests/ptms/core/value_objects/test_money.py
@@ -449,6 +449,42 @@ class TestMoneyUnaryOperations:
         assert money.amount == Decimal("-10.00")
 
 
+class TestMoneyString:
+    def test_str_returns_amount_and_currency(self) -> None:
+        money = Money.of("100.50", CurrencyCode.INR)
+
+        assert str(money) == "100.50 INR"
+
+    def test_str_with_different_currencies(self) -> None:
+        assert str(Money.of("50", CurrencyCode.USD)) == "50 USD"
+        assert str(Money.of("75.25", CurrencyCode.GBP)) == "75.25 GBP"
+        assert str(Money.of("200", CurrencyCode.SGD)) == "200 SGD"
+
+    def test_str_with_negative_amount(self) -> None:
+        money = Money.of("-50.00", CurrencyCode.INR)
+
+        assert str(money) == "-50.00 INR"
+
+    def test_str_preserves_precision(self) -> None:
+        money = Money.of("1.2300", CurrencyCode.USD)
+
+        assert str(money) == "1.2300 USD"
+
+    def test_str_with_zero(self) -> None:
+        money = Money.of("0", CurrencyCode.INR)
+
+        assert str(money) == "0 INR"
+
+    def test_repr_is_different_from_str(self) -> None:
+        money = Money.of("100.50", CurrencyCode.INR)
+
+        representation = repr(money)
+
+        assert "Money" in representation
+        assert "100.50" in representation
+        assert "INR" in representation
+
+
 class TestMoneyInvariants:
     def test_money_is_immutable(self) -> None:
         money = Money.of("100.00", CurrencyCode.USD)


### PR DESCRIPTION
## Why

Money currently lacks a `__str__` method. The ADR compliance review (PTMS-032) flagged this as missing — per the Canonical Representation Principle (ADR-001), every value object must have a canonical string representation.

---

## What

- Added `Money.__str__` returning `"{amount} {currency}"` (e.g. `"100.50 INR"`)
- 6 new tests covering format, currencies, negatives, precision, zero, and repr differentiation

---

## How

`__str__` uses an f-string: `f"{self.amount} {self.currency.value}"`. The Decimal's natural string representation is used without additional formatting or rounding, keeping the Money core precision-preserving.

---

## Tests

```
uv run pytest -q
118 passed in 0.07s
```

```
uv run ruff check . && uv run mypy .
All checks passed!
```

---

## Documentation

`Money.__str__` has a docstring per project convention.

---

## ADR

Yes — addresses the gap identified in ADR-001 (Canonical Representation Principle) and ADR-007.

---

## Review Checklist

- [x] Correctness
- [x] Simplicity
- [x] Readability
- [x] Tests
- [x] Documentation
- [x] Type Safety
- [x] Backward Compatibility
- [ ] Performance (only if relevant)