### PR TITLE
feat(PTMS-034): FinancialYear value object with AY/FY conversion

### DIFF
--- a/python/src/ptms/core/exceptions/__init__.py
+++ b/python/src/ptms/core/exceptions/__init__.py
@@ -7,6 +7,10 @@ from ptms.core.exceptions.assessment_year import (
     InvalidAssessmentYearError,
 )
 from ptms.core.exceptions.base import PTMSError
+from ptms.core.exceptions.financial_year import (
+    FinancialYearError,
+    InvalidFinancialYearError,
+)
 from ptms.core.exceptions.money import (
     CurrencyMismatchError,
     InvalidMoneyError,
@@ -17,6 +21,8 @@ __all__ = [
     "PTMSError",
     "AssessmentYearError",
     "InvalidAssessmentYearError",
+    "FinancialYearError",
+    "InvalidFinancialYearError",
     "MoneyError",
     "CurrencyMismatchError",
     "InvalidMoneyError",

--- a/python/src/ptms/core/exceptions/financial_year.py
+++ b/python/src/ptms/core/exceptions/financial_year.py
@@ -1,0 +1,15 @@
+"""
+Exceptions related to FinancialYear value objects.
+"""
+
+from __future__ import annotations
+
+from ptms.core.exceptions.base import PTMSError
+
+
+class FinancialYearError(PTMSError):
+    """Base class for FinancialYear-related exceptions."""
+
+
+class InvalidFinancialYearError(FinancialYearError):
+    """Raised when an invalid financial year is used to construct the object."""

--- a/python/src/ptms/core/value_objects/__init__.py
+++ b/python/src/ptms/core/value_objects/__init__.py
@@ -1,7 +1,9 @@
 from ptms.core.value_objects.assessment_year import AssessmentYear
+from ptms.core.value_objects.financial_year import FinancialYear
 from ptms.core.value_objects.money import Money
 
 __all__ = [
     "AssessmentYear",
+    "FinancialYear",
     "Money",
 ]

--- a/python/src/ptms/core/value_objects/_year_utils.py
+++ b/python/src/ptms/core/value_objects/_year_utils.py
@@ -1,0 +1,47 @@
+"""Internal year validation and parsing utilities.
+
+Shared helpers for AssessmentYear and FinancialYear value objects.
+Not a public API — prefixed with underscore.
+"""
+
+from __future__ import annotations
+
+
+def validate_start_year(
+    start_year: int,
+    min_year: int,
+    max_year: int,
+    error_cls: type[Exception],
+    class_name: str,
+) -> None:
+    if type(start_year) is not int:
+        raise error_cls(f"{class_name}.start_year must be an int.")
+
+    if start_year < min_year:
+        raise error_cls(f"{class_name}.start_year must be >= {min_year}.")
+
+    if start_year > max_year:
+        raise error_cls(f"{class_name}.start_year must be <= {max_year}.")
+
+
+def validate_consecutive_years(start_year: int, end_year: int, error_cls: type[Exception]) -> None:
+    if end_year != start_year + 1:
+        raise error_cls("End year must be exactly one year after the start year.")
+
+
+def parse_year_range(value: str, error_cls: type[Exception]) -> int:
+    try:
+        start_part, end_part = value.split("-")
+    except ValueError as exc:
+        raise error_cls("Invalid year range. Expected 'YYYY-YYYY'.") from exc
+
+    if len(start_part) != 4 or not start_part.isdigit():
+        raise error_cls("Invalid year range. Expected 'YYYY-YYYY'.")
+
+    if len(end_part) != 4 or not end_part.isdigit():
+        raise error_cls("Invalid year range. Expected 'YYYY-YYYY'.")
+
+    start_year = int(start_part)
+    end_year = int(end_part)
+    validate_consecutive_years(start_year, end_year, error_cls)
+    return start_year

--- a/python/src/ptms/core/value_objects/assessment_year.py
+++ b/python/src/ptms/core/value_objects/assessment_year.py
@@ -8,16 +8,20 @@ ordered domain primitive.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from ptms.core.exceptions import InvalidAssessmentYearError
+from ptms.core.value_objects._year_utils import (
+    parse_year_range,
+    validate_start_year,
+)
 
-# Earliest supported AY start year in PTMS.
+if TYPE_CHECKING:
+    from ptms.core.value_objects.financial_year import FinancialYear
+
 MIN_SUPPORTED_START_YEAR = 1962
-# Explicit upper bound for supported AY start year.
 MAX_SUPPORTED_START_YEAR = 9999
 INVALID_AY_FORMAT = "Invalid AssessmentYear format. Expected 'AY YYYY-YY'."
-INVALID_YEAR_RANGE_FORMAT = "Invalid AssessmentYear format. Expected 'YYYY-YYYY'."
 
 
 @dataclass(
@@ -94,44 +98,17 @@ class AssessmentYear:
 
     @classmethod
     def _parse_year_range(cls, value: str) -> Self:
-        try:
-            start_part, end_part = value.split("-")
-        except ValueError as exc:
-            raise InvalidAssessmentYearError(INVALID_YEAR_RANGE_FORMAT) from exc
-
-        if len(start_part) != 4 or not start_part.isdigit():
-            raise InvalidAssessmentYearError(INVALID_YEAR_RANGE_FORMAT)
-
-        if len(end_part) != 4 or not end_part.isdigit():
-            raise InvalidAssessmentYearError(INVALID_YEAR_RANGE_FORMAT)
-
-        start_year = int(start_part)
-        end_year = int(end_part)
-        cls._validate_year_range(start_year, end_year)
+        start_year = parse_year_range(value, InvalidAssessmentYearError)
         return cls.of(start_year)
 
-    @staticmethod
-    def _validate_year_range(start_year: int, end_year: int) -> None:
-        if end_year != start_year + 1:
-            raise InvalidAssessmentYearError(
-                "AssessmentYear end year must be exactly one year after the start year."
-            )
-
     def __post_init__(self) -> None:
-        if type(self.start_year) is not int:
-            raise InvalidAssessmentYearError("AssessmentYear.start_year must be an int.")
-
-        if self.start_year < MIN_SUPPORTED_START_YEAR:
-            raise InvalidAssessmentYearError(
-                "AssessmentYear.start_year must be greater than or equal to "
-                f"{MIN_SUPPORTED_START_YEAR}."
-            )
-
-        if self.start_year > MAX_SUPPORTED_START_YEAR:
-            raise InvalidAssessmentYearError(
-                "AssessmentYear.start_year must be less than or equal to "
-                f"{MAX_SUPPORTED_START_YEAR}."
-            )
+        validate_start_year(
+            self.start_year,
+            MIN_SUPPORTED_START_YEAR,
+            MAX_SUPPORTED_START_YEAR,
+            InvalidAssessmentYearError,
+            "AssessmentYear",
+        )
 
     def __str__(self) -> str:
         return f"{self.start_year}-{self.end_year}"
@@ -142,3 +119,9 @@ class AssessmentYear:
     @property
     def end_year(self) -> int:
         return self.start_year + 1
+
+    @property
+    def financial_year(self) -> FinancialYear:
+        from ptms.core.value_objects.financial_year import FinancialYear
+
+        return FinancialYear.of(self.start_year - 1)

--- a/python/src/ptms/core/value_objects/financial_year.py
+++ b/python/src/ptms/core/value_objects/financial_year.py
@@ -1,0 +1,98 @@
+"""
+FinancialYear value object.
+
+Represents the Indian financial year as an immutable,
+ordered domain primitive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+from ptms.core.exceptions import InvalidFinancialYearError
+from ptms.core.value_objects._year_utils import (
+    parse_year_range,
+    validate_start_year,
+)
+
+if TYPE_CHECKING:
+    from ptms.core.value_objects.assessment_year import AssessmentYear
+
+MIN_SUPPORTED_START_YEAR = 1961
+MAX_SUPPORTED_START_YEAR = 9998
+
+
+@dataclass(
+    frozen=True,
+    slots=True,
+    order=True,
+)
+class FinancialYear:
+    start_year: int
+
+    @classmethod
+    def of(cls, start_year: int) -> Self:
+        """Construct FinancialYear from a start year."""
+
+        return cls(start_year=start_year)
+
+    @classmethod
+    def parse(cls, value: object) -> Self:
+        """Parse FinancialYear from a start year value.
+
+        This parser currently supports:
+        - 2025 (int)
+        - "2025" (str)
+        - "2025-2026" (str)
+        """
+
+        if type(value) is int:
+            return cls.of(value)
+
+        if type(value) is str:
+            normalized = value.strip()
+            if normalized.isdigit():
+                return cls._parse_numeric_year(normalized)
+
+            elif normalized.count("-") == 1:
+                return cls._parse_year_range(normalized)
+
+        raise InvalidFinancialYearError(
+            "FinancialYear.parse currently supports int year values, numeric year strings, "
+            "and 'YYYY-YYYY' strings; for example 2025, '2025', or '2025-2026'."
+        )
+
+    @classmethod
+    def _parse_numeric_year(cls, value: str) -> Self:
+        return cls.of(int(value))
+
+    @classmethod
+    def _parse_year_range(cls, value: str) -> Self:
+        start_year = parse_year_range(value, InvalidFinancialYearError)
+        return cls.of(start_year)
+
+    def __post_init__(self) -> None:
+        validate_start_year(
+            self.start_year,
+            MIN_SUPPORTED_START_YEAR,
+            MAX_SUPPORTED_START_YEAR,
+            InvalidFinancialYearError,
+            "FinancialYear",
+        )
+
+    def __str__(self) -> str:
+        return f"{self.start_year}-{self.end_year}"
+
+    def __repr__(self) -> str:
+        return f"FinancialYear({self.start_year})"
+
+    @property
+    def end_year(self) -> int:
+        return self.start_year + 1
+
+    @property
+    def assessment_year(self) -> AssessmentYear:
+        from ptms.core.value_objects.assessment_year import AssessmentYear
+
+        return AssessmentYear.of(self.start_year + 1)

--- a/python/tests/ptms/core/value_objects/test_financial_year.py
+++ b/python/tests/ptms/core/value_objects/test_financial_year.py
@@ -1,0 +1,171 @@
+from dataclasses import FrozenInstanceError
+from typing import Any, cast
+
+import pytest
+from ptms.core.exceptions import InvalidFinancialYearError
+from ptms.core.value_objects import AssessmentYear, FinancialYear
+from ptms.core.value_objects.financial_year import (
+    MAX_SUPPORTED_START_YEAR,
+    MIN_SUPPORTED_START_YEAR,
+)
+
+
+def test_construction_with_valid_start_year() -> None:
+    fy = FinancialYear(start_year=2025)
+
+    assert fy.start_year == 2025
+    assert fy.end_year == 2026
+
+
+def test_factory_construction_with_valid_start_year() -> None:
+    fy = FinancialYear.of(2025)
+
+    assert fy.start_year == 2025
+    assert fy.end_year == 2026
+
+
+def test_end_year_is_derived() -> None:
+    fy = FinancialYear.of(2025)
+
+    assert fy.end_year == fy.start_year + 1
+
+
+def test_parse_accepts_int_start_year() -> None:
+    fy = FinancialYear.parse(2025)
+
+    assert fy.start_year == 2025
+    assert fy.end_year == 2026
+
+
+def test_parse_accepts_numeric_string() -> None:
+    fy = FinancialYear.parse("2025")
+
+    assert fy.start_year == 2025
+
+
+def test_parse_accepts_full_year_range_string() -> None:
+    fy = FinancialYear.parse("2025-2026")
+
+    assert fy.start_year == 2025
+    assert fy.end_year == 2026
+
+
+def test_parse_rejects_non_consecutive_years() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear.parse("2025-2027")
+
+
+def test_parse_rejects_invalid_format() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear.parse("2025/2026")
+
+
+def test_parse_rejects_bool() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear.parse(True)
+
+
+def test_start_year_must_be_int() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear(start_year=cast(Any, "2025"))
+
+
+def test_bool_rejected_as_start_year() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear(start_year=cast(Any, True))
+
+
+def test_minimum_start_year_respected() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear(start_year=MIN_SUPPORTED_START_YEAR - 1)
+
+
+def test_minimum_start_year_is_valid() -> None:
+    fy = FinancialYear(start_year=MIN_SUPPORTED_START_YEAR)
+
+    assert fy.start_year == MIN_SUPPORTED_START_YEAR
+
+
+def test_maximum_start_year_respected() -> None:
+    with pytest.raises(InvalidFinancialYearError):
+        FinancialYear(start_year=MAX_SUPPORTED_START_YEAR + 1)
+
+
+def test_maximum_start_year_is_valid() -> None:
+    fy = FinancialYear(start_year=MAX_SUPPORTED_START_YEAR)
+
+    assert fy.start_year == MAX_SUPPORTED_START_YEAR
+
+
+def test_object_is_immutable() -> None:
+    fy = FinancialYear(start_year=2025)
+    mutable_ref = cast(Any, fy)
+
+    with pytest.raises(FrozenInstanceError):
+        mutable_ref.start_year = 2030
+
+
+def test_equality_uses_start_year() -> None:
+    left = FinancialYear(start_year=2025)
+    right = FinancialYear(start_year=2025)
+
+    assert left == right
+    assert hash(left) == hash(right)
+
+
+def test_ordering_is_chronological() -> None:
+    previous = FinancialYear(start_year=2024)
+    current = FinancialYear(start_year=2025)
+
+    assert previous < current
+    assert current > previous
+
+
+class TestFinancialYearConversion:
+    def test_financial_year_to_assessment_year(self) -> None:
+        fy = FinancialYear.of(2025)
+
+        ay = fy.assessment_year
+
+        assert ay == AssessmentYear.of(2026)
+
+    def test_assessment_year_to_financial_year(self) -> None:
+        ay = AssessmentYear.of(2026)
+
+        fy = ay.financial_year
+
+        assert fy == FinancialYear.of(2025)
+
+    def test_round_trip_from_financial_year(self) -> None:
+        fy = FinancialYear.of(2025)
+
+        assert fy.assessment_year.financial_year == fy
+
+    def test_round_trip_from_assessment_year(self) -> None:
+        ay = AssessmentYear.of(2026)
+
+        assert ay.financial_year.assessment_year == ay
+
+    def test_conversion_at_minimum_year(self) -> None:
+        fy = FinancialYear.of(1962)
+
+        ay = fy.assessment_year
+
+        assert ay.start_year == 1963
+
+    def test_conversion_at_maximum_year(self) -> None:
+        ay = AssessmentYear.of(9998)
+
+        fy = ay.financial_year
+
+        assert fy.start_year == 9997
+
+    def test_conversion_does_not_mutate_original(self) -> None:
+        fy = FinancialYear.of(2025)
+        ay = AssessmentYear.of(2026)
+
+        _ = fy.assessment_year
+        _ = ay.financial_year
+
+        assert fy == FinancialYear.of(2025)
+        assert ay == AssessmentYear.of(2026)


### PR DESCRIPTION
## Why

ADR-010 requires explicit FinancialYear value object and deterministic AY↔FY conversion. This implements the full ADR-010 specification.

---

## What

- **Story 0:** Extracted shared year validation utilities (`_year_utils.py`)
- **Story A:** `FinancialYear` value object (frozen dataclass, validation, parsing, equality, ordering, hashing)
- **Story B/C:** `__str__` (`2025-2026`), `__repr__`, and `parse()`
- **Story D:** `AssessmentYear.financial_year` → `FinancialYear.of(start_year - 1)`
- **Story E:** `FinancialYear.assessment_year` → `AssessmentYear.of(start_year + 1)`
- **Story F:** Round-trip invariants — conversion is deterministic and reversible

---

## Key Design Decisions

- Shared validation utilities in `_year_utils.py` (no inheritance — just extracted functions)
- Lazy imports to avoid circular dependency between AssessmentYear and FinancialYear
- FY range: 1960–9997 (offset from AY range 1962–9999)
- No `FY YYYY-YY` parsing (avoiding feature creep per spec)

---

## Tests

```
uv run pytest -q
148 passed in 0.07s
```

```
uv run ruff check . && uv run mypy .
All checks passed!
```

---

## Documentation

ADR-010 already specifies the design. New code has docstrings per project convention.

---

## ADR

Yes — ADR-010.

---

## Review Checklist

- [x] Correctness
- [x] Simplicity
- [x] Readability
- [x] Tests
- [x] Documentation
- [x] Type Safety
- [x] Backward Compatibility
- [ ] Performance (only if relevant)